### PR TITLE
Refactor ParsedMessage

### DIFF
--- a/irckaaja/client.py
+++ b/irckaaja/client.py
@@ -1,6 +1,6 @@
 import time
 from threading import Thread
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, cast
 
 from irckaaja.channel import IrcChannel
 from irckaaja.config import BotConfig, ScriptConfig, ServerConfig
@@ -62,45 +62,36 @@ class IrcClient:
     def _route_message(self, parsed: ParsedMessage) -> None:
         type = parsed.type
 
+        if parsed.message is None:
+            self._unknown_message_received(parsed.raw_message or "")
+            return
+
         if type == MessageType.PRIVATE_MESSAGE:
-            assert parsed.private_message
-            self._private_message_received(parsed.private_message)
+            self._private_message_received(cast(PrivateMessage, parsed.message))
         elif type == MessageType.JOIN:
-            assert parsed.join_message
-            self._join_received(parsed.join_message)
+            self._join_received(cast(JoinMessage, parsed.message))
         elif type == MessageType.PART:
-            assert parsed.part_message
-            self._part_received(parsed.part_message)
+            self._part_received(cast(PartMessage, parsed.message))
         elif type == MessageType.PING:
-            assert parsed.ping_message
-            self._ping_received(parsed.ping_message)
+            self._ping_received(cast(PingMessage, parsed.message))
         elif type == MessageType.QUIT:
-            assert parsed.quit_message
-            self._quit_received(parsed.quit_message)
+            self._quit_received(cast(QuitMessage, parsed.message))
         elif type == MessageType.TOPIC:
-            assert parsed.topic_message
-            self._topic_received(parsed.topic_message)
+            self._topic_received(cast(TopicMessage, parsed.message))
         elif type == MessageType.END_OF_MOTD:
-            assert parsed.end_of_motd_message
-            self._motd_received(parsed.end_of_motd_message)
+            self._motd_received(cast(EndOfMotdMessage, parsed.message))
         elif type == MessageType.TOPIC_REPLY:
-            assert parsed.topic_reply_message
-            self._topic_reply_received(parsed.topic_reply_message)
+            self._topic_reply_received(cast(TopicReplyMessage, parsed.message))
         elif type == MessageType.USERS:
-            assert parsed.users_message
-            self._users_received(parsed.users_message)
+            self._users_received(cast(UsersMessage, parsed.message))
         elif type == MessageType.END_OF_USERS:
-            assert parsed.users_end_message
-            self._users_end_received(parsed.users_end_message)
+            self._users_end_received(cast(UsersEndMessage, parsed.message))
         elif type == MessageType.CHANNEL_MESSAGE:
-            assert parsed.channel_message
-            self._channel_message_received(parsed.channel_message)
-        elif type == MessageType.UNKNOWN:
-            assert parsed.raw_message
-            self._unknown_message_received(parsed.raw_message)
+            self._channel_message_received(cast(ChannelMessage, parsed.message))
         elif type == MessageType.CTCP_VERSION:
-            assert parsed.ctcp_version_message
-            self._ctcp_version_received(parsed.ctcp_version_message)
+            self._ctcp_version_received(
+                cast(CTCPVersionMessage, parsed.message)
+            )
         elif type in [
             MessageType.CTCP_TIME,
             MessageType.CTCP_VERSION,

--- a/tests/test_botscript.py
+++ b/tests/test_botscript.py
@@ -68,9 +68,7 @@ def test_client_calls_script_on_private_message() -> None:
         [
             ParsedMessage(
                 type=MessageType.PRIVATE_MESSAGE,
-                private_message=PrivateMessage(
-                    source=get_user(), message="Hello!"
-                ),
+                message=PrivateMessage(source=get_user(), message="Hello!"),
             )
         ]
     )
@@ -84,7 +82,7 @@ def test_client_calls_script_on_channel_message() -> None:
         [
             ParsedMessage(
                 type=MessageType.CHANNEL_MESSAGE,
-                channel_message=ChannelMessage(
+                message=ChannelMessage(
                     source=get_user(), message="Hello!", channel="#testers"
                 ),
             )
@@ -100,7 +98,7 @@ def test_client_calls_script_on_join() -> None:
         [
             ParsedMessage(
                 type=MessageType.JOIN,
-                join_message=JoinMessage(user=get_user(), channel="#testers"),
+                message=JoinMessage(user=get_user(), channel="#testers"),
             )
         ]
     )
@@ -114,17 +112,15 @@ def test_client_calls_script_on_part() -> None:
         [
             ParsedMessage(
                 type=MessageType.USERS,
-                users_message=UsersMessage(
-                    channel="#testers", users=["tester"]
-                ),
+                message=UsersMessage(channel="#testers", users=["tester"]),
             ),
             ParsedMessage(
                 type=MessageType.END_OF_USERS,
-                users_end_message=UsersEndMessage(channel="#testers"),
+                message=UsersEndMessage(channel="#testers"),
             ),
             ParsedMessage(
                 type=MessageType.PART,
-                part_message=PartMessage(user=get_user(), channel="#testers"),
+                message=PartMessage(user=get_user(), channel="#testers"),
             ),
         ]
     )
@@ -138,17 +134,15 @@ def test_client_calls_script_on_quit() -> None:
         [
             ParsedMessage(
                 type=MessageType.USERS,
-                users_message=UsersMessage(
-                    channel="#testers", users=["tester"]
-                ),
+                message=UsersMessage(channel="#testers", users=["tester"]),
             ),
             ParsedMessage(
                 type=MessageType.END_OF_USERS,
-                users_end_message=UsersEndMessage(channel="#testers"),
+                message=UsersEndMessage(channel="#testers"),
             ),
             ParsedMessage(
                 type=MessageType.QUIT,
-                quit_message=QuitMessage(user=get_user(), message="leaving"),
+                message=QuitMessage(user=get_user(), message="leaving"),
             ),
         ]
     )
@@ -162,7 +156,7 @@ def test_client_calls_script_on_connect() -> None:
         [
             ParsedMessage(
                 type=MessageType.END_OF_MOTD,
-                end_of_motd_message=EndOfMotdMessage(message="welcome"),
+                message=EndOfMotdMessage(message="welcome"),
             )
         ]
     )
@@ -183,7 +177,7 @@ def test_client_calls_script_on_topic() -> None:
         [
             ParsedMessage(
                 type=MessageType.TOPIC,
-                topic_message=TopicMessage(
+                message=TopicMessage(
                     user=get_user(), channel="#testers", topic="welcome"
                 ),
             )
@@ -199,7 +193,7 @@ def test_client_calls_script_on_topic_reply() -> None:
         [
             ParsedMessage(
                 type=MessageType.TOPIC_REPLY,
-                topic_reply_message=TopicReplyMessage(
+                message=TopicReplyMessage(
                     nick=get_user().nick, channel="#testers", topic="welcome"
                 ),
             )

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,6 +1,20 @@
+from typing import cast
+
 from parser_tests import data as parser_test_cases
 
-from irckaaja.protocol import Atoms, MessageParser, MessageType, parse_full_mask
+from irckaaja.protocol import (
+    Atoms,
+    ChannelMessage,
+    JoinMessage,
+    MessageParser,
+    MessageType,
+    PartMessage,
+    PrivateMessage,
+    QuitMessage,
+    UsersEndMessage,
+    UsersMessage,
+    parse_full_mask,
+)
 
 
 def test_private_message() -> None:
@@ -10,9 +24,10 @@ def test_private_message() -> None:
     assert parsed
 
     assert parsed.type == MessageType.PRIVATE_MESSAGE
-    assert parsed.private_message
-    assert parsed.private_message.source.nick == "juke"
-    assert parsed.private_message.message == "lol"
+    assert parsed.message
+    msg = cast(PrivateMessage, parsed.message)
+    assert msg.source.nick == "juke"
+    assert msg.message == "lol"
 
 
 def test_channel_message() -> None:
@@ -21,7 +36,7 @@ def test_channel_message() -> None:
     parsed = parser.parse_message(channel_msg)
     assert parsed
     assert parsed.type == MessageType.CHANNEL_MESSAGE
-    msg = parsed.channel_message
+    msg = cast(ChannelMessage, parsed.message)
     assert msg
     assert msg.source.nick == "juke"
     assert msg.message == "asdfadsf"
@@ -40,7 +55,7 @@ def test_users_message() -> None:
     parsed = parser.parse_message(message)
     assert parsed
     assert parsed.type == MessageType.USERS
-    msg = parsed.users_message
+    msg = cast(UsersMessage, parsed.message)
     assert msg
     assert msg.channel == "#channelname"
     assert msg.users == ["yournick", "@juke"]
@@ -52,7 +67,7 @@ def test_users_end_message() -> None:
     parsed = parser.parse_message(message)
     assert parsed
     assert parsed.type == MessageType.END_OF_USERS
-    msg = parsed.users_end_message
+    msg = cast(UsersEndMessage, parsed.message)
     assert msg
     assert msg.channel == "#channelname"
 
@@ -65,7 +80,7 @@ def test_join_message() -> None:
     parsed = parser.parse_message(message1)
     assert parsed
     assert parsed.type == MessageType.JOIN
-    msg = parsed.join_message
+    msg = cast(JoinMessage, parsed.message)
     assert msg
     assert msg.user.nick == "nick1"
     assert msg.channel == "#channel"
@@ -73,7 +88,7 @@ def test_join_message() -> None:
     parsed = parser.parse_message(message2)
     assert parsed
     assert parsed.type == MessageType.JOIN
-    msg = parsed.join_message
+    msg = cast(JoinMessage, parsed.message)
     assert msg
     assert msg.user.nick == "nick2"
     assert msg.channel == "!channel"
@@ -85,7 +100,7 @@ def test_part_message() -> None:
     parsed = parser.parse_message(message)
     assert parsed
     assert parsed.type == MessageType.PART
-    msg = parsed.part_message
+    msg = cast(PartMessage, parsed.message)
     assert msg
     assert msg.user.nick == "nick"
     assert msg.channel == "#channeltv"
@@ -97,7 +112,7 @@ def test_quit_message() -> None:
     parsed = parser.parse_message(message)
     assert parsed
     assert parsed.type == MessageType.QUIT
-    msg = parsed.quit_message
+    msg = cast(QuitMessage, parsed.message)
     assert msg
     assert msg.user.nick == "nick"
 


### PR DESCRIPTION
This is slightly less type safe before [`assert_type()`](https://docs.python.org/3/library/typing.html#typing.assert_type) can be taken into use (Python 3.11+), but ergonomics is much better.